### PR TITLE
Add option to allow users which are not in /etc/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## LEXIS fork of globus-toolkit to support B2STAGE
+The default grid-mapfile-add-entry code checks that the users are unix usernames in the machine. However, in the B2STAGE scenario, users are verified using tokens and do not exist as unix usernames.
+A new option -force was added to disable this check.
+
 ## Support for open source Globus Toolkit will end as of January 2018; The Globus cloud service and Globus Connect are unaffected
  	
 The Globus team at the University of Chicago has developed and supported the open source [Globus Toolkit](https://www.globustoolkit.org) for close to 20 years. 

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.8
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: grid-mapfile-add-entry
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
-.\"      Date: 09/08/2016
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 06/08/2020
 .\"    Manual: Globus Toolkit Manual
 .\"    Source: Globus Toolkit 6
 .\"  Language: English
 .\"
-.TH "GRID\-MAPFILE\-ADD\-" "8" "09/08/2016" "Globus Toolkit 6" "Globus Toolkit Manual"
+.TH "GRID\-MAPFILE\-ADD\-" "8" "06/08/2020" "Globus Toolkit 6" "Globus Toolkit Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,7 +33,7 @@ grid-mapfile-add-entry \- Add an entry to a gridmap file
 .sp
 \fBgrid\-mapfile\-add\-entry\fR [ \-h | \-help | \-usage | \-version | \-versions ]
 .sp
-\fBgrid\-mapfile\-add\-entry\fR \-dn \fIDISTINGUISHED\-NAME\fR \-ln \fILOCAL\-NAME\fR\&... [\-d | \-dryrun] [ \-f \fIMAPFILE\fR | \-mapfile \fIMAPFILE\fR ] [ \-n ] [ \-c ]
+\fBgrid\-mapfile\-add\-entry\fR \-dn \fIDISTINGUISHED\-NAME\fR \-ln \fILOCAL\-NAME\fR\&... [\-d | \-dryrun] [ \-f \fIMAPFILE\fR | \-mapfile \fIMAPFILE\fR ] [\-force] [ \-n ] [ \-c ]
 .SH "DESCRIPTION"
 .sp
 The \fBgrid\-mapfile\-add\-entry\fR program adds a new mapping from an X\&.509 distinguished name to a local POSIX user name to a gridmap file\&. Gridmap files are used as a simple authorization method for services such as GRAM5 or GridFTP\&.
@@ -72,7 +72,7 @@ The POSIX user name to map the distinguished name to\&. This name must be a vali
 \fILOCAL\-NAME\fR
 strings after the
 \fI\-ln\fR
-command\-line option\&. If any of the local names are invalid, no changes will be made to the gridmap file\&.
+command\-line option\&. If any of the local names are invalid, no changes will be made to the gridmap file (but see force option below)\&.
 .RE
 .PP
 \fB\-d, \-dryrun\fR
@@ -85,6 +85,11 @@ Verify local names and display diagnostics about what would be added to the grid
 Modify the gridmap file named by
 \fIMAPFILE\fR
 instead of the default\&.
+.RE
+.PP
+*\-force
+.RS 4
+Make modifications even if user does not exist (needed for B2STAGE)\&.
 .RE
 .PP
 \fB\-n\fR

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
@@ -58,6 +58,7 @@ Options:
   -dryrun, -d             Shows what would be done but will not add the entry
   -mapfile FILE, -f FILE  Path of Grid map file to be used
 
+  -force                  Make modifications even if user does not exist (needed for B2STAGE)
 EOF
 }
 
@@ -88,7 +89,9 @@ GetOptions(
     "dn=s" => \$dn,
     "ln=s{1,}" => \@ln,
     "d|dryrun" => \$dryrun,
-    "f|mapfile=s" => \$GRID_MAP_FILE);
+    "f|mapfile=s" => \$GRID_MAP_FILE,
+    "force" => \$force);
+
 $lnstring = join(" ", @ln);
 if ($help)
 {
@@ -157,8 +160,10 @@ chmod 0400, $GRID_MAP_FILE
 print "Verifying that Local Name(s)=($lnstring) are legitimate local accounts.\n"
     if ($dryrun);
 
-for my $name (@ln)
+if (not $force)
 {
+ for my $name (@ln)
+  {
     print "Checking ln(s)=$name\n" if ($dryrun);
 
     my @s = getpwnam($name);
@@ -175,6 +180,7 @@ for my $name (@ln)
         print "Result: $res\n" if ($dryrun);
         exit(1);
     }
+  }
 }
 
 print "Local Name(s)=($lnstring) is/are valid. Requested entry will be added.\n"

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.in
@@ -39,6 +39,7 @@ my $NEW_GRID_MAP_FILE;
 my $secconfdir="/etc/grid-security";
 my $GRID_MAP_FILE = $ENV{GRIDMAP} || "${secconfdir}/grid-mapfile";
 my $dryrun = 0;
+my $force = 0;
 
 my $short_usage="$PROGRAM_NAME -dn DN -ln LN [-help] [-d] [-f mapfile FILE]";
 

--- a/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
+++ b/gsi/gss_assist/source/programs/grid-mapfile-add-entry.txt
@@ -14,7 +14,7 @@ SYNOPSIS
 --------
 *grid-mapfile-add-entry* [ -h | -help | -usage | -version | -versions ]
 
-*grid-mapfile-add-entry* -dn 'DISTINGUISHED-NAME' -ln 'LOCAL-NAME'...  [-d | -dryrun] [ -f 'MAPFILE' | -mapfile 'MAPFILE' ] [ -n ] [ -c ]
+*grid-mapfile-add-entry* -dn 'DISTINGUISHED-NAME' -ln 'LOCAL-NAME'...  [-d | -dryrun] [ -f 'MAPFILE' | -mapfile 'MAPFILE' ] [-force] [ -n ] [ -c ] 
 
 DESCRIPTION
 -----------
@@ -56,7 +56,7 @@ The full set of command-line options to *grid-mapfile-add-entry* are:
     The POSIX user name to map the distinguished name to. This name must be a
     valid username. Add multiple 'LOCAL-NAME' strings after the '-ln'
     command-line option. If any of the local names are invalid, no changes will
-    be made to the gridmap file. 
+    be made to the gridmap file (but see force option below). 
 
 *-d, -dryrun*::
     Verify local names and display diagnostics about what would be added to the
@@ -64,6 +64,9 @@ The full set of command-line options to *grid-mapfile-add-entry* are:
 
 *-mapfile 'MAPFILE', -f 'MAPFILE'*::
     Modify the gridmap file named by 'MAPFILE' instead of the default.
+
+*-force::
+    Make modifications even if user does not exist (needed for B2STAGE).
 
 *-n*::
     Don't copy the original file to 'MAPFILE'.old.


### PR DESCRIPTION
In some usecases (e..g B2STAGE) gridftp users are not unix users, and authentification is performed in a different way.
I added an option to allow this usecase.